### PR TITLE
Add iterator.seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Crystal binding for [LevelDB](https://github.com/google/leveldb).
 
 Debian:
 ```
-apt-get install libleveldb-dev libleveldb1 libsnappy1
+sudo apt-get install libleveldb-dev libleveldb1 libsnappy1
 ```
 
 ### shard.yml
@@ -20,8 +20,8 @@ apt-get install libleveldb-dev libleveldb1 libsnappy1
 ```yaml
 dependencies:
   leveldb:
-    github: "crystal-community/leveldb"
-    version: "~> 0.1.0"
+    github: "crystal-community/crystal-leveldb"
+    version: "~> 0.2.0"
 ```
 
 ## Usage
@@ -92,3 +92,4 @@ There is performance comparison of LevelDB and other stores from
 ## Contributors
 
 - [greyblake](https://github.com/greyblake) Sergey Potapov - creator, maintainer
+- [twisterghost](https://github.com/twisterghost) Michael Barrett

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: leveldb
-version: 0.1.0
+version: 0.2.0
 
 authors:
   - Sergey Potapov <blake131313@gmail.com>

--- a/spec/leveldb/iterator_spec.cr
+++ b/spec/leveldb/iterator_spec.cr
@@ -30,4 +30,20 @@ describe LevelDB::Iterator do
     iterator.destroy
     db.close
   end
+
+  it "seeks" do
+    FileUtils.rm_r(TEST_DB) if Dir.exists?(TEST_DB)
+
+    db = LevelDB::DB.new(TEST_DB)
+    db.put("dontseekme", "failure")
+    db.put("seekmeinstead", "success")
+
+    iterator = LevelDB::Iterator.new(db)
+    iterator.seek("seek")
+
+    iterator.key.should eq "seekmeinstead"
+    iterator.value.should eq "success"
+    iterator.destroy
+    db.close
+  end
 end

--- a/src/leveldb/iterator.cr
+++ b/src/leveldb/iterator.cr
@@ -12,6 +12,10 @@ module LevelDB
       LibLevelDB.leveldb_iter_seek_to_last(@iter_ptr)
     end
 
+    def seek(key)
+      LibLevelDB.leveldb_iter_seek(@iter_ptr, key, key.bytesize)
+    end
+
     def valid?
       LibLevelDB.leveldb_iter_valid(@iter_ptr)
     end


### PR DESCRIPTION
Adds `iterator.seek`, allowing users to seek directly to a given key.

The second commit bumps the version, and adds a missing `sudo` to the dependencies install line, as well as adding my info to the contributors list. Let me know if you'd like me to remove that. Bumped to `0.2.0` since its adding a feature, but isn't breaking.