### PR TITLE
Add Ubuntu 18.04 Package Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Crystal binding for [LevelDB](https://github.com/google/leveldb).
 
 Debian:
 ```
-sudo apt-get install libleveldb-dev libleveldb1 libsnappy1
+sudo apt-get install libleveldb-dev libleveldb1v5 libsnappy1v5
 ```
 
 ### shard.yml


### PR DESCRIPTION
When Trying to install libraries on Ubuntu 18.04 results in error:
```bash
$ sudo apt-get install libleveldb-dev libleveldb1 libsnappy1
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package libleveldb1 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libleveldb1v5:i386 libleveldb1v5

Package libsnappy1 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libleveldb1' has no installation candidate
E: Package 'libsnappy1' has no installation candidate
```